### PR TITLE
uevent: Allow multiple uevent listeners from the same process

### DIFF
--- a/uevent/uevent.c
+++ b/uevent/uevent.c
@@ -47,7 +47,7 @@ int uevent_init()
 
     memset(&addr, 0, sizeof(addr));
     addr.nl_family = AF_NETLINK;
-    addr.nl_pid = getpid();
+    addr.nl_pid = 0;
     addr.nl_groups = 0xffffffff;
 
     s = socket(PF_NETLINK, SOCK_DGRAM, NETLINK_KOBJECT_UEVENT);


### PR DESCRIPTION
The netlink socket created by uevent_init sets the nl_pid to the
current PID. nl_pid must be unique per-process, however it does not
have to do with the PID. From the documentation:

"
For a user-space process, nl_pid
is usually the PID of the process owning the destination socket.
However, nl_pid identifies a netlink socket, not a process.  If a
process owns several netlink sockets, then nl_pid can be equal to the
process ID only for at most one socket.
"

In use cases where a single process calls uevent_init more than one
time, the second one will always fail. This patch sets the nl_pid
to 0, which lets the kernel pick its own unique identifier as per the
documentation:

"
If the application sets it to 0, the kernel takes
care of assigning it.  The kernel assigns the process ID to the first
netlink socket the process opens and assigns a unique nl_pid to every
netlink socket that the process subsequently creates.
"

The behavior stays the same for the first socket but will also succeed
in subsequent calls.

Change-Id: I6fa74adc9d5835ff39b86187799998111fc12001
